### PR TITLE
Add t2xco2 to load_dice_iwg_params

### DIFF
--- a/src/core/DICE_main.jl
+++ b/src/core/DICE_main.jl
@@ -147,7 +147,8 @@ function load_dice_iwg_params()
     params[:a1]         = 0.00008162
     params[:a2]         = 0.00204626
     params[:b1]         = 0.00518162                # previously called 'slrcoeff'-- :b1 in SLR
-    params[:b2]         = 0.00305776                # previously called 'slrcoeffsq'-- :b2 in SLR 
+    params[:b2]         = 0.00305776                # previously called 'slrcoeffsq'-- :b2 in SLR
+    params[:t2xco2]     = 3.0
 
     return params
 end


### PR DESCRIPTION
This should fix all the DICE tests.

I think the old version of the code relied on a bug in Mimi that we fixed in Mimi 1.0.0. In particular, the `t2xco2` parameter has a value of 3.2 in the original Nordhaus version. In some older version of Mimi, when one replaced the climate dynamics component with the IWG climate dynamic component, it seems to have used the `default` value from the IWG climate dynamics component for that existing `t2xco2` parameter in the model, even though `t2xco2` of course already had the 3.2 value. So essentially the call to `replace!(m, :climatedynamics => IWG_DICE_climatedynamics)` changed the value of `t2xco2` from 3.2 to 3.0 in an older version of Mimi. I think that was essentially a bug in Mimi, and now in Mimi 1.0.0 that no longer happens. But that also means we need to make sure we actually set the IWG value for `t2xco2` correctly.

I think as a sanity check we should make sure that we don't have the same problem with any of the other `default` values for parameters in components that are defined in this repository here.