### PR TITLE
Add option to save marginal damages vectors in Monte Carlo simulation

### DIFF
--- a/src/core/PAGE_main.jl
+++ b/src/core/PAGE_main.jl
@@ -259,7 +259,7 @@ function get_page_marginaldamages(scenario_choice::scenario_choice, gas::Symbol,
         marg_impacts = marginal[:EquityWeighting, :widt_equityweightedimpact_discounted]
     end
 
-    marg_damages = (marg_impacts .- base_impacts) ./ 100000     # TODO: comment with specified units here
+    marg_damages = (marg_impacts .- base_impacts) ./ (gas == :CO2 ? 100_000 : 1)     # TODO: comment with specified units here
 
     if regional
         return marg_damages

--- a/src/montecarlo/DICE_mcs.jl
+++ b/src/montecarlo/DICE_mcs.jl
@@ -1,6 +1,6 @@
 
 _dice_simdef = @defsim begin
-    # Use the Roe and Baker distribution defined in a file, read in in src/core/constatns.jl
+    # Use the Roe and Baker distribution defined in a file, read in in src/core/constants.jl
     t2xco2 = EmpiricalDistribution(RB_cs_values, RB_cs_probs)
     # save(climatedynamics.t2xco2)
 end 
@@ -30,7 +30,7 @@ function dice_post_trial_func(mcs::SimulationInstance, trial::Int, ntimesteps::I
     (name, rate) = tup
     (base, marginal) = mcs.models
 
-    rates, discount_factors, model_years, horizon, gas, perturbation_years, SCC_values, SCC_values_domestic = Mimi.payload(mcs)
+    rates, discount_factors, model_years, horizon, gas, perturbation_years, SCC_values, SCC_values_domestic, md_values = Mimi.payload(mcs)
 
     last_idx = horizon - 2005 + 1
     annual_years = dice_years[1]:horizon
@@ -54,5 +54,8 @@ function dice_post_trial_func(mcs::SimulationInstance, trial::Int, ntimesteps::I
         scc = sum(annual_md[first_idx:last_idx] ./ DF[1:horizon - pyear + 1])
 
         SCC_values[trial, idx, scenario_num, rate_num] = scc 
+        if md_values !== nothing
+            md_values[idx, scenario_num, :, trial] = md
+        end
     end
 end

--- a/src/montecarlo/FUND_mcs.jl
+++ b/src/montecarlo/FUND_mcs.jl
@@ -166,7 +166,7 @@ function fund_post_trial_func(mcs::SimulationInstance, trialnum::Int, ntimesteps
         end
 
         if md_values !== nothing
-            md_values[j, scenario_num, :, trialnum] = map(x -> ismissing(x) ? 0 : x, global_marginaldamages[1:length(model_years)])
+            md_values[j, scenario_num, :, trialnum] = map(x -> ismissing(x) ? 0 : x, global_marginaldamages[1:length(model_years)]) .* fund_inflator
         end
     end
 end

--- a/src/montecarlo/FUND_mcs.jl
+++ b/src/montecarlo/FUND_mcs.jl
@@ -131,7 +131,7 @@ function fund_post_trial_func(mcs::SimulationInstance, trialnum::Int, ntimesteps
     damages1 = base[:impactaggregation, :loss]
 
     # Unpack the payload object 
-    discount_rates, model_years, gas, perturbation_years, SCC_values, SCC_values_domestic = Mimi.payload(mcs)
+    discount_rates, model_years, gas, perturbation_years, SCC_values, SCC_values_domestic, md_values = Mimi.payload(mcs)
 
     final = length(model_years)
 
@@ -163,6 +163,10 @@ function fund_post_trial_func(mcs::SimulationInstance, trialnum::Int, ntimesteps
             domestic_marginaldamages = marginaldamages[:, 1]
             scc_domestic = _compute_scc(pyear, domestic_marginaldamages, discount_rates)
             SCC_values_domestic[trialnum, j, scenario_num, :] = scc_domestic * fund_inflator
+        end
+
+        if md_values !== nothing
+            md_values[j, scenario_num, :, trialnum] = map(x -> ismissing(x) ? 0 : x, global_marginaldamages[1:length(model_years)])
         end
     end
 end

--- a/src/montecarlo/PAGE_mcs.jl
+++ b/src/montecarlo/PAGE_mcs.jl
@@ -237,7 +237,7 @@ function page_post_trial_func(mcs::SimulationInstance, trialnum::Int, ntimesteps
             base_impacts = base[:EquityWeighting, :wit_equityweightedimpact]
             marg_impacts = marginal[:EquityWeighting, :wit_equityweightedimpact]
         
-            marg_damages = (marg_impacts .- base_impacts) ./ (gas == :CO2 ? 100_000 : 1)
+            marg_damages = (marg_impacts .- base_impacts) ./ (gas == :CO2 ? 100_000 : 1) .* page_inflator
             md_values[j, scenario_num, :, trialnum] = sum(marg_damages, dims = 2) # sum along second dimension to get global values
         end
     end 

--- a/src/montecarlo/PAGE_mcs.jl
+++ b/src/montecarlo/PAGE_mcs.jl
@@ -232,5 +232,13 @@ function page_post_trial_func(mcs::SimulationInstance, trialnum::Int, ntimesteps
             SCC_values_domestic[trialnum, j, scenario_num, rate_num] = scc_domestic
         end
         SCC_values[trialnum, j, scenario_num, rate_num] = scc   
+
+        if md_values !== nothing 
+            base_impacts = base[:EquityWeighting, :wit_equityweightedimpact]
+            marg_impacts = marginal[:EquityWeighting, :wit_equityweightedimpact]
+        
+            marg_damages = (marg_impacts .- base_impacts) ./ (gas == :CO2 ? 100_000 : 1)
+            md_values[j, scenario_num, :, trialnum] = sum(marg_damages, dims = 2) # sum along second dimension to get global values
+        end
     end 
 end

--- a/src/montecarlo/PAGE_mcs.jl
+++ b/src/montecarlo/PAGE_mcs.jl
@@ -206,7 +206,7 @@ function page_post_trial_func(mcs::SimulationInstance, trialnum::Int, ntimesteps
     base, marginal = mcs.models 
 
     # Unpack the payload object 
-    discount_rates, discount_factors, gas, perturbation_years, SCC_values, SCC_values_domestic = Mimi.payload(mcs)
+    discount_rates, discount_factors, gas, perturbation_years, SCC_values, SCC_values_domestic, md_values = Mimi.payload(mcs)
 
     DF = discount_factors[rate_num]
     td_base = base[:EquityWeighting, :td_totaldiscountedimpacts]

--- a/src/montecarlo/run_scc_mcs.jl
+++ b/src/montecarlo/run_scc_mcs.jl
@@ -24,8 +24,8 @@ A new sub directory will be created each time this function is called, with the 
 
 If `tables` equals `true`, then a set of summary statistics tables will also be saved in the output folder.
 If `save_trials` equals `true`, then a file with all of the sampled input trial data will also be saved in
-the output folder. If `save_md` equals `true`, then undiscounted marginal damages from each run of the simulation 
-will be saved in a subdirectory "marginal_damages".
+the output folder. If `save_md` equals `true`, then global undiscounted marginal damages from each run of 
+the simulation will be saved in a subdirectory "marginal_damages".
 """
 function run_scc_mcs(model::model_choice; 
     gas::Union{Symbol, Nothing} = nothing,
@@ -135,7 +135,9 @@ function run_scc_mcs(model::model_choice;
 
     # Make an array to hold undiscounted marginal damages, if specified
     if save_md
-        model == PAGE ? @warn("`save_md = true` not yet implemented for PAGE. No marginal damages output will be saved.") : nothing
+        if model == PAGE && discount_rates != [0.]
+            error("Cannot save undiscounted marginal damages for PAGE unless `discount_rates = [0.]`")
+        end
         md_values = Array{Float64, 4}(undef, length(perturbation_years), length(scenarios), length(model_years), trials)
     else
         md_values = nothing

--- a/src/montecarlo/run_scc_mcs.jl
+++ b/src/montecarlo/run_scc_mcs.jl
@@ -25,7 +25,7 @@ A new sub directory will be created each time this function is called, with the 
 If `tables` equals `true`, then a set of summary statistics tables will also be saved in the output folder.
 If `save_trials` equals `true`, then a file with all of the sampled input trial data will also be saved in
 the output folder. If `save_md` equals `true`, then undiscounted marginal damages from each run of the simulation 
-will be saved in a subdirectory "undiscounted_marginal_damages".
+will be saved in a subdirectory "marginal_damages".
 """
 function run_scc_mcs(model::model_choice; 
     gas::Union{Symbol, Nothing} = nothing,

--- a/src/montecarlo/run_scc_mcs.jl
+++ b/src/montecarlo/run_scc_mcs.jl
@@ -135,7 +135,7 @@ function run_scc_mcs(model::model_choice;
 
     # Make an array to hold undiscounted marginal damages, if specified
     if save_md
-        model == PAGE ? @warn("`save_md = true` not yet implemented for PAGE") : nothing
+        model == PAGE ? @warn("`save_md = true` not yet implemented for PAGE. No marginal damages output will be saved.") : nothing
         md_values = Array{Float64, 4}(undef, length(perturbation_years), length(scenarios), length(model_years), trials)
     else
         md_values = nothing
@@ -160,7 +160,7 @@ function run_scc_mcs(model::model_choice;
 
     # Save the marginal damage matrices
     if save_md
-        md_dir = joinpath(output_dir, "undiscounted_marginal_damages/")
+        md_dir = joinpath(output_dir, "marginal_damages/")
         mkpath(md_dir)
         for (i, year) in enumerate(perturbation_years)
             for (j, scen) in enumerate(scenarios)

--- a/src/montecarlo/run_scc_mcs.jl
+++ b/src/montecarlo/run_scc_mcs.jl
@@ -25,7 +25,7 @@ A new sub directory will be created each time this function is called, with the 
 If `tables` equals `true`, then a set of summary statistics tables will also be saved in the output folder.
 If `save_trials` equals `true`, then a file with all of the sampled input trial data will also be saved in
 the output folder. If `save_md` equals `true`, then global undiscounted marginal damages from each run of 
-the simulation will be saved in a subdirectory "marginal_damages".
+the simulation will be saved in a subdirectory "output/marginal_damages".
 """
 function run_scc_mcs(model::model_choice; 
     gas::Union{Symbol, Nothing} = nothing,
@@ -167,7 +167,7 @@ function run_scc_mcs(model::model_choice;
         for (i, year) in enumerate(perturbation_years)
             for (j, scen) in enumerate(scenarios)
                 fn = joinpath(md_dir, "$scen $year.csv")
-                writedlm(fn, hcat(model_years, md_values[i, j, :, :]), ',')
+                writedlm(fn, hcat(model_years, md_values[i, j, :, :]), ',') # add model year labels as the first column in each file
             end
         end
     end

--- a/src/montecarlo/run_scc_mcs.jl
+++ b/src/montecarlo/run_scc_mcs.jl
@@ -7,6 +7,7 @@
         domestic::Bool = false,
         output_dir::String = nothing, 
         save_trials::Bool = false,
+        save_md::Bool = false,
         tables::Bool = true)
 
 Run the Monte Carlo simulation used by the IWG for calculating a distribution of SCC values for the 
@@ -23,7 +24,8 @@ A new sub directory will be created each time this function is called, with the 
 
 If `tables` equals `true`, then a set of summary statistics tables will also be saved in the output folder.
 If `save_trials` equals `true`, then a file with all of the sampled input trial data will also be saved in
-the output folder.
+the output folder. If `save_md` equals `true`, then undiscounted marginal damages from each run of the simulation 
+will be saved in a subdirectory "undiscounted_marginal_damages".
 """
 function run_scc_mcs(model::model_choice; 
     gas::Union{Symbol, Nothing} = nothing,
@@ -33,6 +35,7 @@ function run_scc_mcs(model::model_choice;
     domestic::Bool = false,
     output_dir::Union{String, Nothing} = nothing, 
     save_trials::Bool = false,
+    save_md::Bool = false,
     tables::Bool = true)
 
     # Check the gas
@@ -130,8 +133,16 @@ function run_scc_mcs(model::model_choice;
         SCC_values_domestic = nothing 
     end
 
+    # Make an array to hold undiscounted marginal damages, if specified
+    if save_md
+        model == PAGE ? @warn("`save_md = true` not yet implemented for PAGE") : nothing
+        md_values = Array{Float64, 4}(undef, length(perturbation_years), length(scenarios), length(model_years), trials)
+    else
+        md_values = nothing
+    end
+
     # Set the payload object
-    push!(payload, [gas, perturbation_years, SCC_values, SCC_values_domestic]...)
+    push!(payload, [gas, perturbation_years, SCC_values, SCC_values_domestic, md_values]...)
     Mimi.set_payload!(mcs, payload)
 
     # Generate trials 
@@ -145,7 +156,19 @@ function run_scc_mcs(model::model_choice;
         scenario_args = scenario_args,
         post_trial_func = post_trial_func
     )
-    SCC_values, SCC_values_domestic = Mimi.payload(sim_results)[end-1:end]
+    SCC_values, SCC_values_domestic, md_values = Mimi.payload(sim_results)[end-2:end]
+
+    # Save the marginal damage matrices
+    if save_md
+        md_dir = joinpath(output_dir, "undiscounted_marginal_damages/")
+        mkpath(md_dir)
+        for (i, year) in enumerate(perturbation_years)
+            for (j, scen) in enumerate(scenarios)
+                fn = joinpath(md_dir, "$scen $year.csv")
+                writedlm(fn, hcat(model_years, md_values[i, j, :, :]), ',')
+            end
+        end
+    end
 
     # generic interpolation if user requested SCC values for years in between model_years
     if _need_to_interpolate


### PR DESCRIPTION
Adds keyword option `save_md = true` to the `run_scc_mcs` function.