### PR TITLE
Fix Compatibility with Mimi v1.2.0

### DIFF
--- a/src/core/DICE_main.jl
+++ b/src/core/DICE_main.jl
@@ -22,7 +22,7 @@ function get_dice_model(scenario_choice::Union{scenario_choice, Nothing}=nothing
 
     # Update all IWG parameter values that are not scenario-specific
     iwg_params = load_dice_iwg_params()
-    update_params!(m, iwg_params, update_timesteps=true)
+    update_params!(m, iwg_params)
 
     # Add the scenario choice component and load all the scenario parameter values
     add_comp!(m, IWG_DICE_ScenarioChoice, :IWGScenarioChoice; before = :grosseconomy)

--- a/src/core/PAGE_main.jl
+++ b/src/core/PAGE_main.jl
@@ -302,7 +302,7 @@ function get_marginal_page_models(; scenario_choice::Union{scenario_choice, Noth
     if year != nothing
         run(base)
         Mimi.build!(marginal)
-        perturb_marginal_page_emissions!(base, marginal, gas, year)
+        marginal = perturb_marginal_page_emissions!(base, marginal, gas, year)
         run(marginal)
     end
 
@@ -339,10 +339,8 @@ function perturb_marginal_page_emissions!(base::Model, marginal::Model, gas::Sym
         update_param!(marginal.mi.md, :add, forcing_shock)
     end
 
-    # create a new model from the marginal model's model instance
-    marginal = Model(marginal.mi)
-
-    return nothing
+    # return a new model from the marginal model's model instance
+    return Model(marginal.mi)
 end  
 
 """

--- a/src/core/PAGE_main.jl
+++ b/src/core/PAGE_main.jl
@@ -18,13 +18,13 @@ function get_page_model(scenario_choice::Union{scenario_choice, Nothing}=nothing
 
     # Update y_year_0 and y_year parameters used by components
     update_param!(m, :y_year_0, 2000)
-    update_param!(m, :y_year, page_years, update_timesteps = true)
+    update_param!(m, :y_year, page_years)
 
     # Update all parameter values (and their timesteps) from the iwg parameters
     for (k, v) in _page_iwg_params
         if Symbol(k) in keys(Mimi.external_params(m))
             if size(v) == (10, 8) || size(v) == (10,)
-                update_param!(m, Symbol(k), v, update_timesteps=true)
+                update_param!(m, Symbol(k), v)
             else
                 update_param!(m, Symbol(k), v)
             end

--- a/src/core/PAGE_main.jl
+++ b/src/core/PAGE_main.jl
@@ -339,6 +339,9 @@ function perturb_marginal_page_emissions!(base::Model, marginal::Model, gas::Sym
         update_param!(marginal.mi.md, :add, forcing_shock)
     end
 
+    # create a new model from the marginal model's model instance
+    marginal = Model(marginal.mi)
+
     return nothing
 end  
 

--- a/src/core/PAGE_main.jl
+++ b/src/core/PAGE_main.jl
@@ -331,7 +331,7 @@ function perturb_marginal_page_emissions!(base::Model, marginal::Model, gas::Sym
         marginal_emissions_growth[i, :] = pulse
 
         # Marginal emissions model
-        md = marginal.mi.md
+        md = marginal.mi.md 
         update_param!(md, :marginal_emissions_growth, marginal_emissions_growth)    # this updates the marginal_emissions_growth parameter that both :er_CO2emissionsgrowth and :AbatementCostsCO2_er_emissionsgrowth are connected to from the PAGE_marginal_emissions comp
     else
         scenario_num = base[:IWGScenarioChoice, :scenario_num]
@@ -339,6 +339,7 @@ function perturb_marginal_page_emissions!(base::Model, marginal::Model, gas::Sym
         update_param!(marginal.mi.md, :add, forcing_shock)
     end
 
+    return nothing
 end  
 
 """

--- a/src/core/PAGE_main.jl
+++ b/src/core/PAGE_main.jl
@@ -331,11 +331,12 @@ function perturb_marginal_page_emissions!(base::Model, marginal::Model, gas::Sym
         marginal_emissions_growth[i, :] = pulse
 
         # Marginal emissions model
-        update_param!(marginal.mi, :marginal_emissions_growth, marginal_emissions_growth)    # this updates the marginal_emissions_growth parameter that both :er_CO2emissionsgrowth and :AbatementCostsCO2_er_emissionsgrowth are connected to from the PAGE_marginal_emissions comp
+        md = marginal.mi.md
+        update_param!(md, :marginal_emissions_growth, marginal_emissions_growth)    # this updates the marginal_emissions_growth parameter that both :er_CO2emissionsgrowth and :AbatementCostsCO2_er_emissionsgrowth are connected to from the PAGE_marginal_emissions comp
     else
         scenario_num = base[:IWGScenarioChoice, :scenario_num]
         forcing_shock = _get_page_forcing_shock(scenario_num, gas, emissionyear)
-        update_param!(marginal.mi, :add, forcing_shock)
+        update_param!(marginal.mi.md, :add, forcing_shock)
     end
 
 end  

--- a/src/core/PAGE_main.jl
+++ b/src/core/PAGE_main.jl
@@ -302,7 +302,7 @@ function get_marginal_page_models(; scenario_choice::Union{scenario_choice, Noth
     if year != nothing
         run(base)
         Mimi.build!(marginal)
-        marginal = perturb_marginal_page_emissions!(base, marginal, gas, year)
+        perturb_marginal_page_emissions!(base, marginal, gas, year)
         run(marginal)
     end
 
@@ -331,16 +331,13 @@ function perturb_marginal_page_emissions!(base::Model, marginal::Model, gas::Sym
         marginal_emissions_growth[i, :] = pulse
 
         # Marginal emissions model
-        md = marginal.mi.md 
-        update_param!(md, :marginal_emissions_growth, marginal_emissions_growth)    # this updates the marginal_emissions_growth parameter that both :er_CO2emissionsgrowth and :AbatementCostsCO2_er_emissionsgrowth are connected to from the PAGE_marginal_emissions comp
+        update_param!(marginal.mi, :marginal_emissions_growth, marginal_emissions_growth)    # this updates the marginal_emissions_growth parameter that both :er_CO2emissionsgrowth and :AbatementCostsCO2_er_emissionsgrowth are connected to from the PAGE_marginal_emissions comp
     else
         scenario_num = base[:IWGScenarioChoice, :scenario_num]
         forcing_shock = _get_page_forcing_shock(scenario_num, gas, emissionyear)
-        update_param!(marginal.mi.md, :add, forcing_shock)
+        update_param!(marginal.mi, :add, forcing_shock)
     end
 
-    # return a new model from the marginal model's model instance
-    return Model(marginal.mi)
 end  
 
 """

--- a/src/montecarlo/PAGE_mcs.jl
+++ b/src/montecarlo/PAGE_mcs.jl
@@ -219,7 +219,7 @@ function page_post_trial_func(mcs::SimulationInstance, trialnum::Int, ntimesteps
     for (j, pyear) in enumerate(perturbation_years)
         idx = getpageindexfromyear(pyear)
 
-        marginal = perturb_marginal_page_emissions!(base, marginal, gas, pyear)
+        perturb_marginal_page_emissions!(base, marginal, gas, pyear)
         run(marginal)
 
         td_marginal = marginal[:EquityWeighting, :td_totaldiscountedimpacts]   

--- a/src/montecarlo/PAGE_mcs.jl
+++ b/src/montecarlo/PAGE_mcs.jl
@@ -219,7 +219,7 @@ function page_post_trial_func(mcs::SimulationInstance, trialnum::Int, ntimesteps
     for (j, pyear) in enumerate(perturbation_years)
         idx = getpageindexfromyear(pyear)
 
-        perturb_marginal_page_emissions!(base, marginal, gas, pyear)
+        marginal = perturb_marginal_page_emissions!(base, marginal, gas, pyear)
         run(marginal)
 
         td_marginal = marginal[:EquityWeighting, :td_totaldiscountedimpacts]   


### PR DESCRIPTION
**Issue 1:**  

We removed the update_timesteps keyword argument from update_param! and update_params!. To prevent this from being a breaking change I then went back and made it deprecated with a warning to avoid users seeing a “no method exists” error when they try to use the update_timesteps keyword argument.  I did not go back and fix update_params!, just update_param! but we use the former in MimiIWG MimiIWG.get_model(DICE, scenario) so that errors.

**Fixes:**

- in Mimi: add the keyword argument with sentinel value back into the update_params! method and then throw a warning when update_timesteps !== nothing instead of forcing for a”no method” error … merge -and then tag Mimi v2.0.1 (PR is here: https://github.com/mimiframework/Mimi.jl/pull/809 
- in MimiIWG: remove the use of update_timesteps keyword argument in future versions of MimiIWG so we avoid the chattiness of the warnings (PR is here: https://github.com/rffscghg/MimiIWG.jl/pull/30)

**Issue 2:** 

The calculation of PAGE’s SCC is wrong now (something like -22000) due to `perturb_marginal_page_emissions!` having to effect on the model instance component parameter values for `:marginal_emissions_growth` parameter ...

**Fix:**  

We were not using `copyto!` in the the call to `update_param!` on a model definition, just directly using `=`, which looks like it. This broke the connection between the the component instance parameter's in `m.mi` and their values in `m.md.external_params` when we called `update_param!` on a `marginal.mi.md`  in `perturb_marginal_page_emissions!` ... so this function didn't change the values for the actual model run.  I fixed that in the Mimi PR [here](https://github.com/mimiframework/Mimi.jl/pull/809) so no need to change anything in MimiIWG!